### PR TITLE
Sync Ruby/zlib version with gem version

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -25,7 +25,7 @@
 # define VALGRIND_MAKE_MEM_UNDEFINED(p, n) 0
 #endif
 
-#define RUBY_ZLIB_VERSION  "0.6.0"
+#define RUBY_ZLIB_VERSION  "1.0.0"
 
 #ifndef GZIP_SUPPORT
 #define GZIP_SUPPORT  1


### PR DESCRIPTION
Sync the version of the Ruby zlib library, Zlib::VERSION,
with the gem version.  (This is not the version of the underlying
zlib library, which can be accessed via Zlib::ZLIB_VERSION.)

I think the gem version should be identical to the library version.
However, this would mean the library version would have to be
switched from 0.6.0 to 1.0.0, against semver.