### PR TITLE
Use Zlib::VERSION in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in zlib.gemspec
-gemspec
+gem "rake"
+gem "rake-compiler"
+
+# Do not use `gemspec' to avoid a gem requirement on the local project.

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,8 @@ Rake::TestTask.new(:test) do |t|
 end
 
 require 'rake/extensiontask'
-Rake::ExtensionTask.new("zlib")
+Rake::ExtensionTask.new("zlib") do |ext|
+  ext.lib_dir = "lib/zlib"
+end
 
 task :default => [:compile, :test]

--- a/ext/zlib/extconf.rb
+++ b/ext/zlib/extconf.rb
@@ -122,7 +122,7 @@ if have_zlib
     have_type('z_crc_t', 'zlib.h')
   end
 
-  create_makefile('zlib') {|conf|
+  create_makefile('zlib/zlib') {|conf|
     if zsrc
       conf.concat addconf if addconf
     end

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -25,8 +25,6 @@
 # define VALGRIND_MAKE_MEM_UNDEFINED(p, n) 0
 #endif
 
-#define RUBY_ZLIB_VERSION  "1.0.0"
-
 #ifndef GZIP_SUPPORT
 #define GZIP_SUPPORT  1
 #endif
@@ -4489,8 +4487,6 @@ Init_zlib(void)
     rb_define_module_function(mZlib, "crc32_combine", rb_zlib_crc32_combine, 3);
     rb_define_module_function(mZlib, "crc_table", rb_zlib_crc_table, 0);
 
-    /* The Ruby/zlib version string. */
-    rb_define_const(mZlib, "VERSION", rb_str_new2(RUBY_ZLIB_VERSION));
     /*  The string which represents the version of zlib.h */
     rb_define_const(mZlib, "ZLIB_VERSION", rb_str_new2(ZLIB_VERSION));
 

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "zlib/zlib"
+require_relative "zlib/version"

--- a/lib/zlib.rb
+++ b/lib/zlib.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "zlib/zlib"
+require "zlib/zlib"
+
 require_relative "zlib/version"

--- a/lib/zlib/version.rb
+++ b/lib/zlib/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Zlib
+
+  # The Ruby/zlib version string.
+  VERSION = "1.0.0"
+end

--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -1085,6 +1085,10 @@ if defined? Zlib
 
   class TestZlib < Test::Unit::TestCase
     def test_version
+      assert_instance_of(String, Zlib::VERSION)
+    end
+
+    def test_zlib_version
       assert_instance_of(String, Zlib.zlib_version)
       assert(Zlib.zlib_version.tainted?)
     end

--- a/zlib.gemspec
+++ b/zlib.gemspec
@@ -1,8 +1,16 @@
 # coding: utf-8
 # frozen_string_literal: true
+
+begin
+  require_relative "lib/zlib/version"
+rescue LoadError
+  # for Ruby core repository
+  require_relative "version"
+end
+
 Gem::Specification.new do |spec|
   spec.name          = "zlib"
-  spec.version       = "1.0.0"
+  spec.version       = Zlib::VERSION
   spec.authors       = ["Yukihiro Matsumoto", "UENO Katsuhiro"]
   spec.email         = ["matz@ruby-lang.org", nil]
 

--- a/zlib.gemspec
+++ b/zlib.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/zlib"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "ext/zlib/extconf.rb", "ext/zlib/zlib.c", "zlib.gemspec"]
+  spec.files         = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "ext/zlib/extconf.rb", "ext/zlib/zlib.c", "lib/zlib.rb", "lib/zlib/version.rb", "zlib.gemspec"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Use the Ruby/zlib version constant in the gemspec to make sure that gem version and library version are always in sync.

In order to achieve this, the definition of Zlib::VERSION is moved from the extension file to a Ruby file; the library structure is changed accordingly.