### PR TITLE
Fix a "missing zlib.c" error when loading the zlib.gemspec outside of ruby-src

### DIFF
--- a/zlib.gemspec
+++ b/zlib.gemspec
@@ -1,6 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
-source_version = File.open(File.join(__dir__, "zlib.c")) {|f|
+zlib_source = [File.join(__dir__, "zlib.c"), File.join(__dir__, "ext", "zlib", "zlib.c")].find { |f| File.file?(f) }
+source_version = File.open(File.realpath(zlib_source)) {|f|
   f.gets("\n#define RUBY_ZLIB_VERSION ")
   f.gets[/\s*(".+")/, 1].undump
 }


### PR DESCRIPTION
There is currently an error that is being raised when working on the gem:

```
[!] There was an error parsing `Gemfile`:
[!] There was an error while loading `zlib.gemspec`: No such file or directory @ rb_sysopen - /Users/colby/Github/zlib/zlib.c. Bundler cannot continue.

 #  from /Users/colby/Github/zlib/zlib.gemspec:3
 #  -------------------------------------------
 #  # frozen_string_literal: true
 >  source_version = File.open(File.join(__dir__, "zlib.c")) {|f|
 #    f.gets("\n#define RUBY_ZLIB_VERSION ")
 #  -------------------------------------------
. Bundler cannot continue.
```

This is occurring because of the change in https://github.com/ruby/zlib/commit/c6d8649ebaf8c99c96402094bb648aabe87dc222 which looks for the `zlib.c` extension in the current folder. While this is correct in ruby-src project, this is not in the gem project as `zlib.c` lives inside `ext/zlib`.

This PR is adding a fix so that the gemspec can be loaded correctly in both projects by checking which file exists.