### PR TITLE
Don't print out warnings when freeing.

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1226,17 +1226,6 @@ zstream_finalize(struct zstream *z)
 	finalizer_warn("the stream was freed prematurely.");
 }
 
-static void
-zstream_free(void *p)
-{
-    struct zstream *z = p;
-
-    if (ZSTREAM_IS_READY(z)) {
-	zstream_finalize(z);
-    }
-    xfree(z);
-}
-
 static size_t
 zstream_memsize(const void *p)
 {
@@ -1246,7 +1235,7 @@ zstream_memsize(const void *p)
 
 static const rb_data_type_t zstream_data_type = {
     "zstream",
-    { zstream_mark, zstream_free, zstream_memsize, },
+    { zstream_mark, xfree, zstream_memsize, },
      0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
There are some cases where you are using a zstream and don't care about the fact that it wasn't "closed". These warnings don't help at all, and create unnecessary output.