### PR TITLE
Revert "Don't print out warnings when freeing."

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1226,6 +1226,17 @@ zstream_finalize(struct zstream *z)
 	finalizer_warn("the stream was freed prematurely.");
 }
 
+static void
+zstream_free(void *p)
+{
+    struct zstream *z = p;
+
+    if (ZSTREAM_IS_READY(z)) {
+	zstream_finalize(z);
+    }
+    xfree(z);
+}
+
 static size_t
 zstream_memsize(const void *p)
 {
@@ -1235,7 +1246,7 @@ zstream_memsize(const void *p)
 
 static const rb_data_type_t zstream_data_type = {
     "zstream",
-    { zstream_mark, xfree, zstream_memsize, },
+    { zstream_mark, zstream_free, zstream_memsize, },
      0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
Reverts ruby/zlib#28, which skips the call to `zstream_finalize` which calls `z->func->end`.
This `func` points to `deflate_funcs` or `inflate_funcs`, and the `end` function is `deflateEnd` or `inflateEnd`.

The comments in zlib.h state that "all dynamically allocated data structures for this stream are freed" by these functions.

```C
ZEXTERN int ZEXPORT deflateEnd OF((z_streamp strm));
/*
     All dynamically allocated data structures for this stream are freed.
   This function discards any unprocessed input and does not flush any pending
   output.

     deflateEnd returns Z_OK if success, Z_STREAM_ERROR if the
   stream state was inconsistent, Z_DATA_ERROR if the stream was freed
   prematurely (some input or output was discarded).  In the error case, msg
   may be set but then points to a static string (which must not be
   deallocated).
*/
```
```C
ZEXTERN int ZEXPORT inflateEnd OF((z_streamp strm));
/*
     All dynamically allocated data structures for this stream are freed.
   This function discards any unprocessed input and does not flush any pending
   output.

     inflateEnd returns Z_OK if success, or Z_STREAM_ERROR if the stream state
   was inconsistent.
*/
```
