### PR TITLE
Mask checksums to lower 32bits

### DIFF
--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -1303,6 +1303,7 @@ if defined? Zlib
       assert_equal(0x02820145, Zlib.adler32("foo"))
       assert_equal(0x02820145, Zlib.adler32("o", Zlib.adler32("fo")))
       assert_equal(0x8a62c964, Zlib.adler32("abc\x01\x02\x03" * 10000))
+      assert_equal(0x97d1a9f7, Zlib.adler32("p", -305419897))
       Tempfile.create("test_zlib_gzip_file_to_io") {|t|
         File.binwrite(t.path, "foo")
         t.rewind
@@ -1338,6 +1339,7 @@ if defined? Zlib
       assert_equal(0x8c736521, Zlib.crc32("foo"))
       assert_equal(0x8c736521, Zlib.crc32("o", Zlib.crc32("fo")))
       assert_equal(0x07f0d68f, Zlib.crc32("abc\x01\x02\x03" * 10000))
+      assert_equal(0xf136439b, Zlib.crc32("p", -305419897))
       Tempfile.create("test_zlib_gzip_file_to_io") {|t|
         File.binwrite(t.path, "foo")
         t.rewind


### PR DESCRIPTION
Upper bits affect the result of `crc32` in zlib 1.2.12.