### PR TITLE
Add truffleruby-head in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
+      versions: '["truffleruby-head"]'
       min_version: 2.7
 
   build:
@@ -23,6 +24,8 @@ jobs:
             os: windows-latest
         exclude:
           - ruby: head
+            os: windows-latest
+          - ruby: truffleruby-head
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -506,6 +506,7 @@ if defined? Zlib
     end
 
     def test_multithread_deflate
+      pend 'hangs' if RUBY_ENGINE == 'truffleruby'
       zd = Zlib::Deflate.new
 
       s = "x" * 10000
@@ -522,6 +523,7 @@ if defined? Zlib
     end
 
     def test_multithread_inflate
+      pend 'hangs' if RUBY_ENGINE == 'truffleruby'
       zi = Zlib::Inflate.new
 
       s = Zlib.deflate("x" * 10000)
@@ -792,7 +794,7 @@ if defined? Zlib
       }
     end
 
-    if defined? File::TMPFILE
+    if defined?(File::TMPFILE) and RUBY_ENGINE != 'truffleruby'
       def test_path_tmpfile
         sio = StringIO.new("".dup, 'w')
         gz = Zlib::GzipWriter.new(sio)


### PR DESCRIPTION
* The latest release does not have this fix: https://github.com/oracle/truffleruby/commit/c77f8bb35db084c99d1f5b14748267866004222e

cc @segiddins who is interested in this for https://github.com/ruby/zlib/pull/61