### PR TITLE
Travis CI: Enhance, and print the used zlib deb package name and the version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-dist: jammy
 language: ruby
-matrix:
-  include:
-    - arch: s390x
+arch: s390x
+dist: jammy
+before_install:
+  # Print the used zlib deb package version.
+  - |
+    dpkg -s "$(dpkg -S /usr/include/zlib.h | cut -d ":" -f 1)"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zlib
 
+[![Build Status](https://app.travis-ci.com/ruby/zlib.svg?branch=master)](https://app.travis-ci.com/ruby/zlib)
+
 This module provides access to the [zlib library](http://zlib.net). Zlib is designed to be a portable, free, general-purpose, legally unencumbered -- that is, not covered by any patents -- lossless data-compression library for use on virtually any computer hardware and operating system.
 
 The zlib compression library provides in-memory compression and decompression functions, including integrity checks of the uncompressed data.


### PR DESCRIPTION
I would like to merge this PR after Travis CI is enabled for this repository. Note that the badge image is not available yet.

---

* Print the used zlib deb package name and the version for debugging use.
* Refactor .travis.yml.
  * Set the language syntax defining some default behaviors first, aligning with ruby/ruby's .travis.yml
  * Remove the matrix syntax for now. Simplify the file.
* Add Travis badge image to `README.md`.