### PR TITLE
Rakefile: Update the test task to pass on Ubuntu jammy s390x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-dist: jammy
 language: ruby
-matrix:
-  include:
-    - arch: s390x
+arch: s390x
+dist: jammy
+before_install:
+  # Print the used zlib deb package version.
+  - |
+    dpkg -s "$(dpkg -S /usr/include/zlib.h | cut -d ":" -f 1)"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,16 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+desc "Run tests"
+task :test do
+  # Avoid possible test failures with the zlib applying the following patch on
+  # s390x CPU architecture.
+  # https://github.com/madler/zlib/pull/410
+  ENV["DFLTCC"] = "0" if RUBY_PLATFORM =~ /s390x/
+  Rake::Task["test_internal"].invoke
+end
+
+Rake::TestTask.new(:test_internal) do |t|
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]

--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -12,10 +12,6 @@ rescue LoadError
 end
 
 if defined? Zlib
-  child_env = {}
-  child_env['DFLTCC'] = '0' if RUBY_PLATFORM =~ /s390x/
-  Zlib::CHILD_ENV = child_env.freeze
-
   class TestZlibDeflate < Test::Unit::TestCase
     def test_initialize
       z = Zlib::Deflate.new
@@ -48,63 +44,59 @@ if defined? Zlib
     end
 
     def test_deflate_chunked
-      assert_separately([Zlib::CHILD_ENV, '-rzlib'], <<~'end;')
-        original = ''.dup
-        chunks = []
-        r = Random.new 0
+      original = ''.dup
+      chunks = []
+      r = Random.new 0
 
-        z = Zlib::Deflate.new
+      z = Zlib::Deflate.new
 
-        2.times do
-          input = r.bytes(20000)
-          original << input
-          z.deflate(input) do |chunk|
-            chunks << chunk
-          end
+      2.times do
+        input = r.bytes(20000)
+        original << input
+        z.deflate(input) do |chunk|
+          chunks << chunk
         end
+      end
 
-        assert_equal [16384, 16384],
-                     chunks.map { |chunk| chunk.length }
+      assert_equal [16384, 16384],
+                   chunks.map { |chunk| chunk.length }
 
-        final = z.finish
+      final = z.finish
 
-        assert_equal 7253, final.length
+      assert_equal 7253, final.length
 
-        chunks << final
-         all = chunks.join
+      chunks << final
+      all = chunks.join
 
-        inflated = Zlib.inflate all
+      inflated = Zlib.inflate all
 
-        assert_equal original, inflated
-      end;
+      assert_equal original, inflated
     end
 
     def test_deflate_chunked_break
-      assert_separately([Zlib::CHILD_ENV, '-rzlib'], <<~'end;')
-        chunks = []
-        r = Random.new 0
+      chunks = []
+      r = Random.new 0
 
-        z = Zlib::Deflate.new
+      z = Zlib::Deflate.new
 
-        input = r.bytes(20000)
-        z.deflate(input) do |chunk|
-          chunks << chunk
-          break
-        end
+      input = r.bytes(20000)
+      z.deflate(input) do |chunk|
+        chunks << chunk
+        break
+      end
 
-        assert_equal [16384], chunks.map { |chunk| chunk.length }
+      assert_equal [16384], chunks.map { |chunk| chunk.length }
 
-        final = z.finish
+      final = z.finish
 
-        assert_equal 3632, final.length
+      assert_equal 3632, final.length
 
-        all = chunks.join
-        all << final
+      all = chunks.join
+      all << final
 
-        original = Zlib.inflate all
+      original = Zlib.inflate all
 
-        assert_equal input, original
-      end;
+      assert_equal input, original
     end
 
     def test_addstr
@@ -960,32 +952,30 @@ if defined? Zlib
     end
 
     def test_unused2
-      assert_separately([Zlib::CHILD_ENV, '-rzlib', '-rstringio'], <<~'end;')
-        zio = StringIO.new
+      zio = StringIO.new
 
-        io = Zlib::GzipWriter.new zio
-        io.write 'aaaa'
-        io.finish
+      io = Zlib::GzipWriter.new zio
+      io.write 'aaaa'
+      io.finish
 
-        io = Zlib::GzipWriter.new zio
-        io.write 'bbbb'
-        io.finish
+      io = Zlib::GzipWriter.new zio
+      io.write 'bbbb'
+      io.finish
 
-        zio.rewind
+      zio.rewind
 
-        io = Zlib::GzipReader.new zio
-        assert_equal('aaaa', io.read)
-        unused = io.unused
-        assert_equal(24, unused.bytesize)
-        io.finish
+      io = Zlib::GzipReader.new zio
+      assert_equal('aaaa', io.read)
+      unused = io.unused
+      assert_equal(24, unused.bytesize)
+      io.finish
 
-        zio.pos -= unused.length
+      zio.pos -= unused.length
 
-        io = Zlib::GzipReader.new zio
-        assert_equal('bbbb', io.read)
-        assert_equal(nil, io.unused)
-        io.finish
-      end;
+      io = Zlib::GzipReader.new zio
+      assert_equal('bbbb', io.read)
+      assert_equal(nil, io.unused)
+      io.finish
     end
 
     def test_read
@@ -1412,46 +1402,36 @@ if defined? Zlib
     end
 
     def test_deflate_stream
-      assert_separately([Zlib::CHILD_ENV, '-rzlib'], <<~'end;')
-        r = Random.new 0
+      r = Random.new 0
 
-        deflated = ''.dup
+      deflated = ''.dup
 
-        Zlib.deflate(r.bytes(20000)) do |chunk|
-          deflated << chunk
-        end
+      Zlib.deflate(r.bytes(20000)) do |chunk|
+        deflated << chunk
+      end
 
-        assert_equal 20016, deflated.length
-      end;
+      assert_equal 20016, deflated.length
     end
 
     def test_gzip
-      assert_separately([Zlib::CHILD_ENV, '-rzlib'], <<~'end;')
-        actual = Zlib.gzip("foo".freeze)
-        actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
-        actual[9] = "\xff" # replace OS
-        expected = %w[1f8b08000000000000ff4bcbcf07002165738c03000000].pack("H*")
-        assert_equal expected, actual
-      end;
-    end
+      actual = Zlib.gzip("foo".freeze)
+      actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
+      actual[9] = "\xff" # replace OS
+      expected = %w[1f8b08000000000000ff4bcbcf07002165738c03000000].pack("H*")
+      assert_equal expected, actual
 
-    def test_gzip_level_0
       actual = Zlib.gzip("foo".freeze, level: 0)
       actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
       actual[9] = "\xff" # replace OS
       expected = %w[1f8b08000000000000ff010300fcff666f6f2165738c03000000].pack("H*")
       assert_equal expected, actual
-    end
 
-    def test_gzip_level_9
       actual = Zlib.gzip("foo".freeze, level: 9)
       actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
       actual[9] = "\xff" # replace OS
       expected = %w[1f8b08000000000002ff4bcbcf07002165738c03000000].pack("H*")
       assert_equal expected, actual
-    end
 
-    def test_gzip_level_9_filtered
       actual = Zlib.gzip("foo".freeze, level: 9, strategy: Zlib::FILTERED)
       actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
       actual[9] = "\xff" # replace OS


### PR DESCRIPTION
This PR is a rework for the https://github.com/ruby/zlib/pull/63, to make the workaround simple. Because I was inspired by the comment at https://github.com/ruby/spec/pull/1084#issuecomment-1739243422.

The PR has 3 commit.

The 1st commit is to improve `.travis.yml` printing [the used zlib deb package version and other info](https://app.travis-ci.com/github/junaruga/ruby-zlib/builds/266278031#L114).

The 2nd commit reverts the commit 9f3b9c470c05b9a65e4f74ef8aeace792976fb69.

The 3rd commit is the main commit for this PR, setting the environment variable `DFLTCC=0`. When running `test/**/test_*.rb"` as a child process from the Ruby code in the `Rakefile` as a parent process. the environment variable can affect to the tests in the test file. I referred to the way of `test` task calling the `test-internal`, seeing the following ruby/openssl's `Rakefile`.

https://github.com/ruby/openssl/blob/6b3dd6a372c5eabc88bf35a312937ee3e1a6a105/Rakefile#L21-L35

I confirmed that the [Travis CI passing in my forked repository](https://app.travis-ci.com/github/junaruga/ruby-zlib/builds/266278031
). When running 2 times, the total running times are 28 seconds and 31 seconds. So, it's faster than [GitHub Actions around 2 minutes 30 seconds ~ 7 minutes](https://github.com/ruby/zlib/actions/workflows/test.yml?query=branch%3Amaster)
.

@jeremyevans Could you review? The change is essentially only for the 3rd commit, as I was able to revert the 2nd commit without conflict.


