### PR TITLE
Fix misdetection of {crc32,alder32}_z in cloudflare zlib fork

### DIFF
--- a/ext/zlib/extconf.rb
+++ b/ext/zlib/extconf.rb
@@ -120,12 +120,16 @@ if have_zlib
     $defs << "-DHAVE_CRC32_COMBINE"
     $defs << "-DHAVE_ADLER32_COMBINE"
     $defs << "-DHAVE_TYPE_Z_CRC_T"
-    $defs << "-DHAVE_TYPE_Z_SIZE_T"
+    $defs << "-DHAVE_CRC32_Z"
+    $defs << "-DHAVE_ADLER32_Z"
+    $defs << "-DHAVE_ZLIB_SIZE_T_FUNCS"
   else
     have_func('crc32_combine', 'zlib.h')
     have_func('adler32_combine', 'zlib.h')
     have_type('z_crc_t', 'zlib.h')
-    have_type('z_size_t', 'zlib.h')
+    if have_func('crc32_z', 'zlib.h') && have_func('adler32_z', 'zlib.h')
+      $defs << "-DHAVE_ZLIB_SIZE_T_FUNCS"
+    end
   end
 
   create_makefile('zlib') {|conf|

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -44,7 +44,7 @@
 #endif
 #endif
 
-#if defined(HAVE_TYPE_Z_SIZE_T)
+#if defined(HAVE_ZLIB_SIZE_T_FUNCS)
 typedef uLong (*checksum_func)(uLong, const Bytef*, z_size_t);
 # define crc32 crc32_z
 # define adler32 adler32_z
@@ -388,7 +388,7 @@ rb_zlib_version(VALUE klass)
 # define mask32(x) (x)
 #endif
 
-#if SIZEOF_LONG > SIZEOF_INT && !defined(HAVE_TYPE_Z_SIZE_T)
+#if SIZEOF_LONG > SIZEOF_INT && !defined(HAVE_ZLIB_SIZE_T_FUNCS)
 static uLong
 checksum_long(uLong (*func)(uLong, const Bytef*, uInt), uLong sum, const Bytef *ptr, long len)
 {


### PR DESCRIPTION
We use the Cloudflare fork of zlib
(https://github.com/cloudflare/zlib), which we find gives improved performance on AWS Graviton ARM instances. That fork does not define crc32_z and alder32_z functions.

Until two days ago, Ruby's zlib gem worked fine, because cloudflare zlib _also_ did not define z_size_t, which meant Ruby did not try and use these functions.

Since https://github.com/cloudflare/zlib/commit/a3ba99596d6271224d39ef9d6853511f51821e05 however, cloudflare zlib _does_ define z_size_t (but NOT crc32_z or alder32_z). The zlib gem would try and use these nonexistant functions and not compile.

This patch fixes it by actually specifically detecting the functions that the gem wants to call, rather than just the presence of the z_size_t type.