### PR TITLE
In Zlib::GzipReader#eof? check if we're actually at eof

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -3500,6 +3500,9 @@ static VALUE
 rb_gzfile_eof_p(VALUE obj)
 {
     struct gzfile *gz = get_gzfile(obj);
+    while (!ZSTREAM_IS_FINISHED(&gz->z) && ZSTREAM_BUF_FILLED(&gz->z) == 0) {
+	gzfile_read_more(gz, Qnil);
+    }
     return GZFILE_IS_FINISHED(gz) ? Qtrue : Qfalse;
 }
 


### PR DESCRIPTION
When checking for `eof?`, read ahead until we can confidently say that either there is more content or the stream is finished. If reading ahead fills the `z->buf`, we are not at eof.

It's possible that only empty blocks or the footer remain to be read from the input stream. If `eof?` is only based on current status of the stream, a following read may produce no output, causing an EOFError because there's nothing left to return. This only happens for very specific gzip file lengths that hit exactly at a modulo of the read size, leaving only empty blocks and the footer remaining to be read.

Fixes #56