### PR TITLE
Fix eof? to return true when there is no more data to read

### DIFF
--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -1208,8 +1208,7 @@ if defined? Zlib
     # Test boundary cases around compressed data where the "final" deflate block is empty,
     # and close to a Zlib::GzipFile::READ_SIZE boundary
     [(Zlib::GzipFile::READ_SIZE - 30)..(Zlib::GzipFile::READ_SIZE - 10), (Zlib::GzipFile::READ_SIZE * 2 - 30)..(Zlib::GzipFile::READ_SIZE * 2 - 10)].flat_map(&:to_a).each do |size|
-      contents = "a\n" * (size / 2)
-      contents << "\n" if size.odd?
+      contents = "a\n" * ((size + 1) / 2)
       contents.freeze
 
       s = StringIO.new


### PR DESCRIPTION
Even if the stream is not yet finished

Similar to Socket/Pipe, we need to check if there is any actual data left,
as it is possible that the stream is not finished, but there is no data that
would be returned upon reading, so we want to report eof? in that case

Fixes #56

Tests comprehensively cover the corner cases of the deflate block boundary falling around multiples of 2048 bytes, which is the chunk size the input is read in.