### PR TITLE
Investigate failure on truffleruby-head + macOS + XCode 14.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-11, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         include:
           - ruby: mswin
             os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         include:
           - ruby: mswin
             os: windows-latest
@@ -48,3 +48,4 @@ jobs:
       env:
         TESTOPTS: "--verbose"
         TRUFFLERUBYOPT: "--experimental-options --cexts-log-load"
+        MACOSX_DEPLOYMENT_TARGET: "11.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,15 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # 'bundle install' and cache
+    - run: env | sort
+    - run: |
+        cc -xc -E - <<EOF
+        #include <dlfcn.h>
+        foo(RTLD_LAZY, RTLD_NOW, RTLD_LOCAL, RTLD_GLOBAL);
+        EOF
     - name: Run test
       run: bundle exec rake compile test
       timeout-minutes: 5
       env:
         TESTOPTS: "--verbose"
+        TRUFFLERUBYOPT: "--experimental-options --cexts-log-load"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-11, windows-latest ]
         include:
           - ruby: mswin
             os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,5 @@ jobs:
     - name: Run test
       run: bundle exec rake compile test
       timeout-minutes: 5
+      env:
+        TESTOPTS: "--verbose"

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -2965,6 +2965,7 @@ gzfile_read_all(struct gzfile *gz)
     return gzfile_newstr(gz, dst);
 }
 
+__attribute__((__noinline__))
 static VALUE
 gzfile_getc_dummy_encoding(struct gzfile *gz)
 {


### PR DESCRIPTION
From https://github.com/ruby/zlib/pull/73#issuecomment-1890427228

```
Run bundle exec rake compile test
mkdir -p lib
mkdir -p tmp/x86_64-darwin20/zlib/3.2.2
/Users/runner/.rubies/truffleruby-head/bin/ruby -I. ../../../../ext/zlib/extconf.rb
cd tmp/x86_64-darwin20/zlib/3.2.2
checking for deflateReset(NULL) in -lz... yes
checking for crc32_combine() in zlib.h... yes
checking for adler32_combine() in zlib.h... yes
checking for z_crc_t in zlib.h... yes
checking for z_size_t in zlib.h... yes
checking for crc32_z() in zlib.h... yes
checking for adler32_z() in zlib.h... yes
creating Makefile
cd -
cd tmp/x86_64-darwin20/zlib/3.2.2
/usr/bin/make
compiling ../../../../ext/zlib/zlib.c
linking shared-object zlib.bundle
ld: warning: -undefined dynamic_lookup may not work with chained fixups
cd -
/usr/bin/make install sitearchdir=../../../../lib sitelibdir=../../../../lib target_prefix=
mkdir -p tmp/x86_64-darwin20/stage/lib
/usr/bin/install -c -m 0755 zlib.bundle ../../../../lib
cp tmp/x86_64-darwin20/zlib/3.2.2/zlib.bundle tmp/x86_64-darwin20/stage/lib/zlib.bundle
<internal:core> core/kernel.rb:234:in `gem_original_require': dlopen(/Users/runner/work/zlib/zlib/lib/zlib.bundle, 0x0009): symbol not found in flat namespace (_rb_econv_check_error) (RuntimeError)
	from <internal:/Users/runner/.rubies/truffleruby-head/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/runner/work/zlib/zlib/test/zlib/test_zlib.rb:10:in `<top (required)>'
	from <internal:core> core/kernel.rb:234:in `gem_original_require'
	from <internal:/Users/runner/.rubies/truffleruby-head/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/runner/work/zlib/zlib/vendor/bundle/truffleruby/3.2.2.9/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /Users/runner/work/zlib/zlib/vendor/bundle/truffleruby/3.2.2.9/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /Users/runner/work/zlib/zlib/vendor/bundle/truffleruby/3.2.2.9/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
/Users/runner/work/zlib/zlib/rakefile:10:in `block in <top (required)>'
/Users/runner/work/zlib/zlib/vendor/bundle/truffleruby/3.2.2.9/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
<internal:core> core/kernel.rb:383:in `load'
<internal:core> core/kernel.rb:383:in `load'
<internal:core> core/kernel.rb:383:in `load'
/Users/runner/.rubies/truffleruby-head/bin/bundle:44:in `<main>'
Tasks: TOP => test_internal
(See full trace by running task with --trace)
```