### PR TITLE
Revert "Switch to macos-13 in CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         include:
           - ruby: mswin
             os: windows-latest


### PR DESCRIPTION
* This reverts commit ef35c855e4d1d0df266baae7e8e97a2d5e69ed50.
* No longer needed thanks to https://github.com/ruby/setup-ruby/pull/561