### PR TITLE
Add `compile` task in Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ puts "Uncompressed data is: #{uncompressed_data}"
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake compile test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
When I followed the instructions in the Development section, I found some tests failing with Ruby 3.3.1 and older Rubies:

<details>
<summary>failure log</summary>

```bash
$ rake test
Loaded suite /Users/sangenya/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started
P
===================================================================================================================================================================================================================================================================================================================
Pending: test_gunzip_no_memory_leak(TestZlib): pended.
/Users/sangenya/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/test-unit-ruby-core-1.0.5/lib/core_assertions.rb:192:in `rescue in assert_no_memory_leak'
/Users/sangenya/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/test-unit-ruby-core-1.0.5/lib/core_assertions.rb:150:in `assert_no_memory_leak'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1528:in `test_gunzip_no_memory_leak'
     1525:     end
     1526: 
     1527:     def test_gunzip_no_memory_leak
  => 1528:       assert_no_memory_leak(%[-rzlib], "#{<<~"{#"}", "#{<<~'};'}")
     1529:       d = Zlib.gzip("data")
     1530:       {#
     1531:         10_000.times {Zlib.gunzip(d)}
===================================================================================================================================================================================================================================================================================================================
E
===================================================================================================================================================================================================================================================================================================================
Error: test_gzfile_read_size_boundary(TestZlibGzipReader): EOFError: end of file reached
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1249:in `readpartial'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1249:in `block (2 levels) in test_gzfile_read_size_boundary'
     1246:         end
     1247: 
     1248:         Zlib::GzipReader.open(t.path) do |f|
  => 1249:           f.readpartial(1024) until f.eof?
     1250:           assert_raise(EOFError) { f.readpartial(1) }
     1251:         end
     1252: 
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1248:in `open'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1248:in `block in test_gzfile_read_size_boundary'
/Users/sangenya/.rbenv/versions/3.3.0/lib/ruby/3.3.0/tempfile.rb:447:in `create'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1237:in `test_gzfile_read_size_boundary'
===================================================================================================================================================================================================================================================================================================================
E
===================================================================================================================================================================================================================================================================================================================
Error: test_read(TestZlibGzipReader): ArgumentError: wrong number of arguments (given 2, expected 0..1)
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1000:in `read'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:1000:in `block (2 levels) in test_read'
      997: 
      998:           assert_raise(ArgumentError) { f.read(-1, s) }
      999: 
  => 1000:           assert_same s, f.read(1, s)
     1001:           assert_equal "\xE3".b, s
     1002: 
     1003:           assert_same s, f.read(2, s)
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:995:in `open'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:995:in `block in test_read'
/Users/sangenya/.rbenv/versions/3.3.0/lib/ruby/3.3.0/tempfile.rb:447:in `create'
/Users/sangenya/dev/zlib/test/zlib/test_zlib.rb:985:in `test_read'
===================================================================================================================================================================================================================================================================================================================
Finished in 0.74951 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
95 tests, 520 assertions, 0 failures, 2 errors, 1 pendings, 0 omissions, 0 notifications
96.8421% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
126.75 tests/s, 693.79 assertions/s
rake aborted!
Command failed with status (1)
/Users/sangenya/dev/zlib/Rakefile:10:in `block in <top (required)>'
Tasks: TOP => test_internal
(See full trace by running task with --trace)
```

</details>

It turned out that this was because I had not executed the `rake compile` before running `rake test`.
We should have `compile` task in the Development section so that new contributors don't stumble.

FYI: CI runs `rake compile test`.
https://github.com/ruby/zlib/blob/950dad7f4da38011db610bffb4d69f4080d76648/.github/workflows/test.yml#L42