### PR TITLE
Bump up 3.1.1

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -25,7 +25,7 @@
 # define VALGRIND_MAKE_MEM_UNDEFINED(p, n) 0
 #endif
 
-#define RUBY_ZLIB_VERSION "3.1.0"
+#define RUBY_ZLIB_VERSION "3.1.1"
 
 #ifndef RB_PASS_CALLED_KEYWORDS
 # define rb_class_new_instance_kw(argc, argv, klass, kw_splat) rb_class_new_instance(argc, argv, klass)


### PR DESCRIPTION
As per https://bugs.ruby-lang.org/issues/20289, I backported only that change to ruby/ruby `ruby_3_3`. In case zlib.gem is written in Gemfile/Gemfile.lock, I think we should have a compatible release on rubygems.org. I created `3-1-stable` branch in this repository and pushed the same backport change.

@hsbt I'll release it as part of Ruby 3.3.2. Could you merge this and release this `3-1-stable` branch as 3.1.1?