### PR TITLE
Reenable Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+arch: s390x
+dist: jammy
+before_install:
+  # Print the used zlib deb package version.
+  - |
+    dpkg -s "$(dpkg -S /usr/include/zlib.h | cut -d ":" -f 1)"


### PR DESCRIPTION
There was a report that the Travis CI's long-term infra issue was addressed by the Travis team on the [Ruby Bug ticket 20810](https://bugs.ruby-lang.org/issues/20810).

This PR reverts the past commit dropping Travis CI.

Note that in my tests in my forked repository, I saw the s390x job is delayed to start around a few minutes.

Revert "Retired Travis CI"

This reverts commit eefc054744a34484688c3bc7987bf974933be4f9.