### PR TITLE
CI: Skip ppc64le/s390x cases in forked repositories.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
       run: bundle exec rake compile test
       timeout-minutes: 5
 
-  test2:
+  build-ibm:
+    if: github.repository == 'ruby/zlib'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
/cc @hsbt 

This PR is a follow up of the https://github.com/ruby/zlib/pull/101.

The GitHub Actions ppc64le/s390x runners don't work on forked repositories such as the following case. These only work on the registered repositories.

https://github.com/junaruga/ruby-zlib/actions/runs/16466060209/job/46543627022