### PR TITLE
Drop older rubies than 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     with:
       engine: cruby
       versions: '["truffleruby-head"]'
-      min_version: 2.5
+      min_version: 2.7
 
   build:
     needs: ruby-versions
@@ -24,8 +24,6 @@ jobs:
           - ruby: mingw
             os: windows-latest
         exclude:
-          - ruby: 2.5
-            os: macos-latest
           - ruby: head
             os: windows-latest
           - ruby: truffleruby-head

--- a/zlib.gemspec
+++ b/zlib.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
   spec.extensions    = "ext/zlib/extconf.rb"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 end


### PR DESCRIPTION
This library already uses designated initializers, that is a C99 feature.
C99 has been adopted since ruby 2.7.

This is an alternative to #124.