### PR TITLE
Initialize zstream state

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -651,6 +651,7 @@ zstream_init(struct zstream *z, const struct zstream_funcs *func)
     z->stream.avail_in = 0;
     z->stream.next_out = Z_NULL;
     z->stream.avail_out = 0;
+    z->stream.state = Z_NULL;
     z->func = func;
 }
 

--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -1524,6 +1524,8 @@ if defined? Zlib
     end
 
     def test_gzip
+      assert_raise(Zlib::StreamError) { Zlib.gzip("foo", level: 100) }
+
       actual = Zlib.gzip("foo".freeze)
       actual[4, 4] = "\x00\x00\x00\x00" # replace mtime
       actual[9] = "\xff" # replace OS


### PR DESCRIPTION
Calling `Zlib.gzip` with an invalid compression level should raise `Zlib::StreamError`, consistently with `Zlib::Deflate` and `Zlib::GzipWriter`.

On several Ruby/platform combinations, the failed `deflateInit2` call leaves `z_stream.state` uninitialized. The subsequent gzip cleanup can then pass that invalid pointer into `deflate`, causing a segmentation fault.

This initializes `z_stream.state` to `Z_NULL` and adds a regression test for the invalid-level path.

The failure was originally observed here:

https://github.com/socketry/protocol-grpc/actions/runs/31685751610/job/94401275917?pr=7