### PR TITLE
Fix SIGSEGV in Deflate#params when called before any output

### DIFF
--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1945,7 +1945,8 @@ rb_deflate_params(VALUE obj, VALUE v_level, VALUE v_strategy)
     if (err != Z_OK) {
 	raise_zlib_error(err, z->stream.msg);
     }
-    rb_str_set_len(z->buf, RSTRING_LEN(z->buf) + filled);
+    if (!NIL_P(z->buf))
+	rb_str_set_len(z->buf, RSTRING_LEN(z->buf) + filled);
 
     return Qnil;
 }

--- a/test/zlib/test_zlib.rb
+++ b/test/zlib/test_zlib.rb
@@ -216,6 +216,13 @@ if defined? Zlib
       z.close # without this, outputs `zlib(finalizer): the stream was freed prematurely.'
     end
 
+    def test_params_before_output
+      z = Zlib::Deflate.new
+      EnvUtil.suppress_warning {z.params(Zlib::BEST_COMPRESSION, Zlib::DEFAULT_STRATEGY)}
+      z << "foo"
+      assert_equal("foo", Zlib::Inflate.inflate(z.finish))
+    end
+
     def test_set_dictionary
       z = Zlib::Deflate.new
       z.set_dictionary("foo")


### PR DESCRIPTION
`Deflate#params` crashes the interpreter when called on a stream that has not produced any output yet, because `z->buf` is still `Qnil` at that point and `rb_str_set_len` is called on it unconditionally. When no bytes were flushed `filled` is 0 and there is nothing to append, so guard the final `rb_str_set_len` with a `NIL_P(z->buf)` check, matching the guards already used throughout the file. Added a regression test that calls `params` before any output. Fixes #143.
